### PR TITLE
moved the proxy path setting.  Fixes #27

### DIFF
--- a/lib/proxy-ticket.js
+++ b/lib/proxy-ticket.js
@@ -10,7 +10,6 @@ module.exports = function(options){
     options = _.extend({}, options, configuration());
     if (!options.targetService) throw new Error('no target proxy service specified');
 
-    options.pathname = options.paths.proxy;
     options.query = options.query || {};
     options.query.targetService = options.targetService;
 
@@ -19,7 +18,8 @@ module.exports = function(options){
         if (req.pt && req.pt[options.targetService]) return next();
 
         options.query.pgt = req.session.pgt;
-
+        options.pathname = options.paths.proxy;
+        
         request.get(url.format(options), function(err, res, body){
             if (err || res.statusCode !== 200) return redirectToLogin(options, req, res);
             if (/<cas:proxySuccess/.exec(body)) {


### PR DESCRIPTION
In the case where `serviceValidate()` is placed before `proxyTicket()` middleware, it is possible for the options.pathname to be modified [service-validate:30](https://github.com/AceMetrix/connect-cas/blob/master/lib/service-validate.js#L30).

Since `proxyTicket` middleware does not subsequently overwrite this value, when connect calls the function, it will use the wrong pathname to verify.

This PR moves the value to after the handler so that `proxyTicket` can overwrite the value like the other middleware.
