### PR TITLE
Example app with CAS-authenticated login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Adapted from https://github.com/jmarca/cas_validate
 ## Installation
 
     npm install connect-cas
-            
+
 ## Options
 
 Many of these options are borrowed from node's [url documentation](http://nodejs.org/api/url.html).  You may set global options through the `.configure()` method or override them with any of the exposed middleware.
@@ -34,6 +34,15 @@ connect()
   .use(cas.serviceValidate())
   .use(cas.authenticate())
 ```
+
+## Complete Example
+
+A more complete example of a simple Express app that uses CAS for login, displays the CAS username, and offers a logout link can be found in the `example` folder. You'll need to copy `example/app.js` to your own folder and install its dependencies:
+
+    npm install express
+    npm install connect-cas
+
+Express is required only for the example app. It is not required for `connect-cas`.
 
 ## Proxy Tickets
 

--- a/example/app.js
+++ b/example/app.js
@@ -1,0 +1,58 @@
+// A simple Express app demonstrating CAS authentication.
+// Login is required for the "/login" URL, but not for
+// the home page. The home page is aware of logins and
+// can display the username.
+//
+// Copy this to a folder of your own and be sure to run
+// "npm install express" and "npm install connect-cas".
+
+var express = require('express');
+var cas = require('connect-cas');
+var url = require('url');
+
+// Your CAS server's hostname
+cas.configure({ 'host': 'cas.YOURSCHOOLHERE.edu' });
+console.log(cas.configure());
+var app = express();
+
+// Use cookie sessions for simplicity, you can use something else
+app.use(express.cookieParser('this should be random and secure'));
+app.use(express.cookieSession());
+
+app.get('/', function(req, res) {
+  if (req.session.cas && req.session.cas.user) {
+    return res.send('<p>You are logged in. Your username is ' + req.session.cas.user + '. <a href="/logout">Log Out</a></p>');
+  } else {
+    return res.send('<p>You are not logged in. <a href="/login">Log in now.</a><p>');
+  }
+});
+
+// This route has the serviceValidate middleware, which verifies
+// that CAS authentication has taken place, and also the
+// authenticate middleware, which requests it if it has not already
+// taken place.
+
+app.get('/login', cas.serviceValidate(), cas.authenticate(), function(req, res) {
+  // Great, we logged in, now redirect back to the home page.
+  return res.redirect('/');
+});
+
+app.get('/logout', function(req, res) {
+  if (!req.session) {
+    return res.redirect('/');
+  }
+  // Forget our own login session
+  if (req.session.destroy) {
+    req.session.destroy();
+  } else {
+    // Cookie-based sessions have no destroy()
+    req.session = null;
+  }
+  // Send the user to the official campus-wide logout URL
+  var options = cas.configure();
+  options.pathname = options.paths.logout;
+  return res.redirect(url.format(options));
+});
+
+app.listen(3000);
+


### PR DESCRIPTION
This is a great module but when I picked it up I was pretty fuzzy on how to put it to work. The documentation is a little thin on those basics.

As a code sample for other CAS newcomers, I've submitted a tiny Express app that demonstrates a public homepage, a protected login URL that redirects back to the homepage, displaying the username on the homepage if logged in, and logging out correctly.