### PR TITLE
Update service-validate to support cookie sessions

### DIFF
--- a/lib/service-validate.js
+++ b/lib/service-validate.js
@@ -44,29 +44,40 @@ module.exports = function (overrides) {
             return;
         }
 
+        // redis session
         if (req.sessionStore) {
             // Have I already validated this ticket?
             req.sessionStore.get(req.session.id, function (err, storedSession) {
                 if (storedSession && storedSession.st && (storedSession.st === ticket)) {
                     return next();
                 } else {
-                    request.get(formatUrl(options), function(casErr, casRes, casBody){
-                        if (casErr || casRes.statusCode !== 200){
-                            res.send(403);
-                            return;
-                        }
-
+                    validateService(res, formatUrl(options), function (casBody) {
                         validateCasResponse(req, res, ticket, casBody, options, next);
                     });
                 }
 
             });
+        // cookie session
         } else {
-            return next();
+            validateService(res, formatUrl(options), function (casBody) {
+                validateCasResponse(req, res, ticket, casBody, options, next);
+            });
         }
 
     };
 };
+
+function validateService(res, url, callback) {
+
+    request.get(url, function(casErr, casRes, casBody){
+        if (casErr || casRes.statusCode !== 200){
+            res.send(403);
+            return;
+        }
+        callback(casBody);
+    });
+
+}
 
 function validateCasResponse(req, res, ticket, casBody, options, next) {
     xml2js(casBody, {explicitRoot: false, tagNameProcessors: [stripPrefix]}, function(err, serviceResponse) {


### PR DESCRIPTION
I'm using this module in one of my node apps and it works great. I'm using an http cookie to manage user sessions instead of redis. I ran into a problem when upgrading to 1.4.2 which caused the service validate endpoint to never get called since `req.sessionStore` doesn't exist when not using redis. It seems the upgrade to 1.4.2 broke support for http cookie sessions. This PR adds back support for cookie sessions.
