### PR TITLE
cas redirect not working for /authenticate/login endpoint 

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -4,5 +4,5 @@ module.exports.origin = function(req){
     var query = req.query;
     if (query.ticket) delete query.ticket;
     var querystring = qs.stringify(query);
-    return req.protocol + '://' + req.get('host') + req.path + (querystring ? '?' + querystring : '');
+    return req.protocol + '://' + req.get('host') + req._parsedOriginalUrl.pathname + (querystring ? '?' + querystring : '');
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,8 +1,8 @@
 var qs = require('querystring');
-
+var url = require("url");
 module.exports.origin = function(req){
     var query = req.query;
     if (query.ticket) delete query.ticket;
     var querystring = qs.stringify(query);
-    return req.protocol + '://' + req.get('host') + req._parsedOriginalUrl.pathname + (querystring ? '?' + querystring : '');
+    return req.protocol + '://' + req.get('host') + url.parse(req.originalUrl).pathname + (querystring ? '?' + querystring : '');
 };


### PR DESCRIPTION
When the login endpoint is inside another route, other than index (/authenticate/login), redirect to /login instead.

part of request object included for review- 
_parsedOriginalUrl:
   { protocol: null,
     slashes: null,
     auth: null,
     host: null,
     port: null,
     hostname: null,
     hash: null,
     search: null,
     query: null,
     pathname: '/authenticate/login',
     path: '/authenticate/login',
     href: '/authenticate/login',
     _raw: '/authenticate/login' },
  sessionStore:
   { sessions: { nhi_54kpnp3vRkKSbu4hXiyMupoAHp4z: '{"cookie":{"originalMaxAge":null,"expires":null,"httpOnly":true,"path":"/"}}' },
     generate: [Function],
     _events: { disconnect: [Function], connect: [Function] } },
  sessionID: 'nhi_54kpnp3vRkKSbu4hXiyMupoAHp4z',
  session:
   { cookie:
      { path: '/',
        _expires: null,
        originalMaxAge: null,
        httpOnly: true } },
  route:
   { path: '/login',
     stack: [ [Object], [Object], [Object] ],
     methods: { get: true } } }