### PR TITLE
[Enhancement #35] Replaced arbitrary HTTP Status Codes with Enums

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,6 +1,7 @@
 var origin = require('./util').origin;
 var url = require('url');
 var _ = require('lodash');
+var HttpStatus = require('http-status-codes');
 
 module.exports = function(overrides){
     var configuration = require('./configure')();
@@ -17,6 +18,6 @@ module.exports = function(overrides){
         options.pathname = options.paths.login;
         options.query = options.query || {};
         options.query.service = origin(req);
-        res.redirect(307, url.format(options));
+        res.redirect(HttpStatus.TEMPORARY_REDIRECT, url.format(options));
     };
 };

--- a/lib/proxy-ticket.js
+++ b/lib/proxy-ticket.js
@@ -2,6 +2,7 @@ var url = require('url');
 var configuration = require('./configure');
 var request = require('request');
 var _ = require('lodash');
+var HttpStatus = require('http-status-codes');
 var q = require('q');
 var authenticate = require('./authenticate');
 var origin = require('./util').origin;
@@ -21,7 +22,7 @@ module.exports = function(options){
         options.pathname = options.paths.proxy;
         
         request.get(url.format(options), function(err, res, body){
-            if (err || res.statusCode !== 200) return redirectToLogin(options, req, res);
+            if (err || res.statusCode !== HttpStatus.OK) return redirectToLogin(options, req, res);
             if (/<cas:proxySuccess/.exec(body)) {
                 if (/<cas:proxyTicket>(.*)<\/cas:proxyTicket>/.exec(body)){
                     req.pt = req.pt || {};
@@ -36,5 +37,5 @@ function redirectToLogin(options, req, res){
     options.pathname = options.paths.login;
     options.query = {};
     options.query.service = origin(req);
-    res.redirect(307, url.format(options));
+    res.redirect(HttpStatus.TEMPORARY_REDIRECT, url.format(options));
 }

--- a/lib/service-validate.js
+++ b/lib/service-validate.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var parseUrl = require('url').parse;
 var formatUrl = require('url').format;
 var request = require('request');
+var HttpStatus = require('http-status-codes');
 var xml2js = require('xml2js').parseString;
 var stripPrefix = require('xml2js/lib/processors').stripPrefix;
 
@@ -17,7 +18,7 @@ module.exports = function (overrides) {
         if (options.pgtFn && !options.pgtUrl) throw new Error('pgtUrl must be specified for obtaining proxy tickets');
 
         if (!req.session){
-            res.send(503);
+            res.send(HttpStatus.SERVICE_UNAVAILABLE);
             return;
         }
 
@@ -33,10 +34,10 @@ module.exports = function (overrides) {
             options.query.pgtUrl = pgtPathname ? req.protocol + '://' + req.get('host') + pgtPathname : options.pgtUrl;
 
         if (pgtPathname && req.path === pgtPathname && req.method === 'GET') {
-            if (!req.query.pgtIou || !req.query.pgtId) return res.send(200);
+            if (!req.query.pgtIou || !req.query.pgtId) return res.send(HttpStatus.OK);
 
             req.sessionStore.set(req.query.pgtIou, _.extend(req.session, {pgtId: req.query.pgtId}));
-            return res.send(200);
+            return res.send(HttpStatus.OK);
         }
 
         if (!ticket){
@@ -70,8 +71,8 @@ module.exports = function (overrides) {
 function validateService(res, url, callback) {
 
     request.get(url, function(casErr, casRes, casBody){
-        if (casErr || casRes.statusCode !== 200){
-            res.send(403);
+        if (casErr || casRes.statusCode !== HttpStatus.OK){
+            res.send(HttpStatus.UNAUTHORIZED);
             return;
         }
         callback(casBody);
@@ -93,7 +94,7 @@ function validateCasResponse(req, res, ticket, casBody, options, next) {
 
         if (!serviceResponse) {
             console.error('Invalid CAS server response.');
-            res.send(500);
+            res.send(HttpStatus.INTERNAL_SERVER_ERROR);
             return;
         }
 
@@ -119,7 +120,7 @@ function validateCasResponse(req, res, ticket, casBody, options, next) {
 
         if (options.pgtFn) {
             options.pgtFn.call(null, pgtIou, function(err, pgt){
-                if (err) return res.send(502);
+                if (err) return res.send(HttpStatus.BAD_GATEWAY);
                 req.session.pgt = pgt;
                 next();
             });

--- a/lib/ssout.js
+++ b/lib/ssout.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var HttpStatus = require('http-status-codes');
 
 module.exports = function(serviceUrl){
     return function(req,res,next){
@@ -24,8 +25,8 @@ module.exports = function(serviceUrl){
             req.sessionStore.get(st, function(err, result){
                 if (result && result.sid) req.sessionStore.destroy(result.sid);
                 req.sessionStore.destroy(st);
-            })
-            res.send(204);
+            });
+            res.send(HttpStatus.NO_CONTENT);
         });
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-cas",
   "description": "Connect middleware for a node CAS client",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": "Duncan Wong <baduncaduncan@gmail.com>",
   "license": "MIT",
   "keywords": [
@@ -21,9 +21,10 @@
     "test": "./node_modules/.bin/mocha --reporter list test/*.spec.js"
   },
   "dependencies": {
-    "request": "~2.30.0",
+    "http-status-codes": "^1.0.5",
     "lodash": "~2.4.1",
     "q": "~1.0.0",
+    "request": "~2.30.0",
     "xml2js": "~0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
In an effort to improve code readability I imported the node package http-status-codes so we can use enum labels that denote what the status code means