### PR TITLE
Add optional service URL to config

### DIFF
--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -17,7 +17,7 @@ module.exports = function(overrides){
         }
         options.pathname = options.paths.login;
         options.query = options.query || {};
-        options.query.service = origin(req);
+        options.query.service = options.service || origin(req);
         res.redirect(HttpStatus.TEMPORARY_REDIRECT, url.format(options));
     };
 };

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -4,6 +4,7 @@ var defaults = {
     host: undefined,
     hostname: undefined, // ex. google
     port: 443,
+    service: undefined,
     paths: {
         validate: '/cas/validate',               // not implemented
         serviceValidate: '/cas/serviceValidate', // CAS 2.0

--- a/lib/service-validate.js
+++ b/lib/service-validate.js
@@ -26,7 +26,7 @@ module.exports = function (overrides) {
         var ticket = (url.query && url.query.ticket) ? url.query.ticket : null;
 
         options.query = options.query || {};
-        options.query.service = origin(req);
+        options.query.service = options.service || origin(req);
         options.query.ticket = ticket;
         options.pathname = options.paths.serviceValidate;
 


### PR DESCRIPTION
I have a node application with node behind a HTTPS proxy and the service URL is not generated properly.

I've added a "service" parameter to configuration object where you can force the service url to be one you need, with the proper server name and protocol
