### PR TITLE
Remove target service check in proxy-ticket

### DIFF
--- a/lib/proxy-ticket.js
+++ b/lib/proxy-ticket.js
@@ -16,7 +16,7 @@ module.exports = function(options){
 
     return function(req, res, next){
         if (!req.session.pgt) return redirectToLogin(options, req, res);
-        if (req.pt && req.pt[options.targetService]) return next();
+        if (req.session.pt && req.session.pt[options.targetService]) return next();
 
         options.query.pgt = req.session.pgt;
         options.pathname = options.paths.proxy;
@@ -27,6 +27,8 @@ module.exports = function(options){
                 if (/<cas:proxyTicket>(.*)<\/cas:proxyTicket>/.exec(body)){
                     req.pt = req.pt || {};
                     req.pt[options.targetService] = RegExp.$1;
+                    req.session.pt = req.session.pt || {};
+                    req.session.pt[options.targetService] = RegExp.$1;
                 }
             }
             next();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-cas",
   "description": "Connect middleware for a node CAS client",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "author": "Duncan Wong <baduncaduncan@gmail.com>",
   "license": "MIT",
   "keywords": [

--- a/test/proxy-ticket.spec.js
+++ b/test/proxy-ticket.spec.js
@@ -48,8 +48,8 @@ describe('#proxyTicket', function(){
         });
         it('sets req.pt', function(done){
             request.get('https://localhost:3000/asdf', function(err, res, body){
-                should.exist(lastRequest.pt);
-                should.exist(lastRequest.pt['atyourservice']);
+                should.exist(lastRequest.session.pt);
+                should.exist(lastRequest.session.pt['atyourservice']);
                 done();
             });
         });

--- a/test/proxy-ticket.spec.js
+++ b/test/proxy-ticket.spec.js
@@ -54,11 +54,11 @@ describe('#proxyTicket', function(){
             });
         });
     });
-    describe('when req.pt already exists', function(){
+    describe('when req.session.pt already exists', function(){
         before(function(done){
             option.beforeMiddleware = function(req, res, next){
                 req.session.pgt = 'validPGT';
-                req.pt = {'atyourservice': 'some-PT'}
+                req.session.pt = {'atyourservice': 'some-PT'}
                 next();
             };
             casServer = casServerSetup(function(){
@@ -68,7 +68,7 @@ describe('#proxyTicket', function(){
 
         it('leaves the pt intact when it already exists', function(done){
              request.get('https://localhost:3000/asdf', function(err, res, body){
-                lastRequest.pt['atyourservice'].should.equal('some-PT');
+                lastRequest.session.pt['atyourservice'].should.equal('some-PT');
                 done();
             });
         });


### PR DESCRIPTION
The feature for checking the target service for the existing proxy ticket was not working, because no target service was being stored, so it always evaluated to false. I removed this check to avoid continuously getting unnecessary proxy tickets from CAS. If in the future we need to store multiple proxy tickets for different target services then we will need to update how this information is stored. For now it assumes only a single service is proxied.