### PR TITLE
Prevent race condition by moving options inside middleware. Closes #48

### DIFF
--- a/lib/service-validate.js
+++ b/lib/service-validate.js
@@ -9,11 +9,9 @@ var stripPrefix = require('xml2js/lib/processors').stripPrefix;
 
 module.exports = function (overrides) {
     var configuration = require('./configure')();
-    var options = _.extend({}, configuration, overrides);
-
-    var pgtPathname = pgtPath(options);
-
     return function(req,res,next){
+        var options = _.extend({}, configuration, overrides);
+        var pgtPathname = pgtPath(options);
         if (!options.host && !options.hostname) throw new Error('no CAS host specified');
         if (options.pgtFn && !options.pgtUrl) throw new Error('pgtUrl must be specified for obtaining proxy tickets');
 


### PR DESCRIPTION
Moving these variables into the closure prevents the race condition.