### PR TITLE
Fixed the `npm audit` vulnerabilities warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   },
   "dependencies": {
     "http-status-codes": "^1.0.5",
-    "lodash": "~2.4.1",
+    "lodash": "^4.17.11",
     "q": "~1.0.0",
-    "request": "~2.81.0",
+    "request": "^2.88.0",
     "xml2js": "~0.4.1"
   },
   "devDependencies": {
-    "mocha": "~1.9.0",
-    "should": "~1.2.2",
-    "connect": "~2.7.6",
-    "express": "~3.2.0",
-    "connect-redis": "~1.4.5"
+    "connect": "^3.6.6",
+    "connect-redis": "~1.4.5",
+    "express": "^4.16.4",
+    "mocha": "^6.0.2",
+    "should": "~1.2.2"
   },
   "bugs": {
     "url": "https://github.com/AceMetrix/connect-cas/issues"


### PR DESCRIPTION
There were a lot of vulnerabilities warnings including a critical one. Used `npm audit fix --force` to automatically update the dependencies.

```
found 33 vulnerabilities (9 low, 13 moderate, 10 high, 1 critical) 
```