### PR TITLE
ensure pgtIou&pgtId are correctly stored before responding to CAS server

### DIFF
--- a/lib/service-validate.js
+++ b/lib/service-validate.js
@@ -34,8 +34,10 @@ module.exports = function (overrides) {
         if (pgtPathname && req.path === pgtPathname && req.method === 'GET') {
             if (!req.query.pgtIou || !req.query.pgtId) return res.send(HttpStatus.OK);
 
-            req.sessionStore.set(req.query.pgtIou, _.extend(req.session, {pgtId: req.query.pgtId}));
-            return res.send(HttpStatus.OK);
+            req.sessionStore.set(req.query.pgtIou, _.extend(req.session, {pgtId: req.query.pgtId}), function () {
+                return res.send(HttpStatus.OK);
+            });
+            return;
         }
 
         if (!ticket){


### PR DESCRIPTION
without this fix, there is a race and retrievePGTFromPGTIOU can fail (happened with session-file-store with option { retries: 0 })